### PR TITLE
Fix source code display

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -2,70 +2,70 @@
 
 @font-face{
 	font-family: 'FontAwesome';
-	src: url('../fonts/font-awesome.woff2') format('woff2'), url('fonts/font-awesome.woff') format('woff');
+	src: local('FontAwesome'), url('../fonts/font-awesome.woff2') format('woff2'), url('fonts/font-awesome.woff') format('woff');
 	font-weight: normal;
 	font-style: normal;
 }
 
 @font-face{
 	font-family: 'League Spartan';
-	src: url('../fonts/league-spartan-bold.woff2') format('woff2'), url('fonts/league-spartan-bold.woff') format('woff');
+	src: local('League Spartan'), url('../fonts/league-spartan-bold.woff2') format('woff2'), url('fonts/league-spartan-bold.woff') format('woff');
 	font-weight: bold;
 	font-style: normal;
 }
 
 @font-face{
 	font-family: "Crimson Text";
-	src: url('../fonts/crimson-text.woff2') format('woff2'), url('fonts/crimson-text.woff') format('woff');
+	src: local('Crimson Text'), url('../fonts/crimson-text.woff2') format('woff2'), url('fonts/crimson-text.woff') format('woff');
 	font-weight: normal;
 	font-style: normal;
 }
 
 @font-face{
 	font-family: "Crimson Text";
-	src: url('../fonts/crimson-text-bold.woff2') format('woff2'), url('fonts/crimson-text-bold.woff') format('woff');
+	src: local('Crimson Text'), url('../fonts/crimson-text-bold.woff2') format('woff2'), url('fonts/crimson-text-bold.woff') format('woff');
 	font-weight: bold;
 	font-style: normal;
 }
 
 @font-face{
 	font-family: "Crimson Text";
-	src: url('../fonts/crimson-text-italic.woff2') format('woff2'), url('fonts/crimson-text-italic.woff') format('woff');
-	font-weight: normal;
-	font-style: italic;
-}
-
-@font-face{
-	font-family: "Crimson Text";
-	src: url('../fonts/crimson-text-bold-italic.woff2') format('woff2'), url('fonts/crimson-text-bold-italic.woff') format('woff');
-	font-weight: bold;
-	font-style: italic;
-}
-
-@font-face{
-	font-family: "Source Code Pro";
-	src: url('../fonts/source-code-pro.woff2') format('woff2'), url('fonts/source-code-pro.woff') format('woff');
-	font-weight: normal;
-	font-style: normal;
-}
-
-@font-face{
-	font-family: "Source Code Pro";
-	src: url('../fonts/source-code-pro-bold.woff2') format('woff2'), url('fonts/source-code-pro-bold.woff') format('woff');
-	font-weight: bold;
-	font-style: normal;
-}
-
-@font-face{
-	font-family: "Source Code Pro";
-	src: url('../fonts/source-code-pro-italic.woff2') format('woff2'), url('fonts/source-code-pro-italic.woff') format('woff');
+	src: local('Crimson Text'), url('../fonts/crimson-text-italic.woff2') format('woff2'), url('fonts/crimson-text-italic.woff') format('woff');
 	font-weight: normal;
 	font-style: italic;
 }
 
 @font-face{
+	font-family: "Crimson Text";
+	src: local('Crimson Text'), url('../fonts/crimson-text-bold-italic.woff2') format('woff2'), url('fonts/crimson-text-bold-italic.woff') format('woff');
+	font-weight: bold;
+	font-style: italic;
+}
+
+@font-face{
 	font-family: "Source Code Pro";
-	src: url('../fonts/source-code-pro-bold-italic.woff2') format('woff2'), url('fonts/source-code-pro-bold-italic.woff') format('woff');
+	src: local('Source Code Pro'), url('../fonts/source-code-pro.woff2') format('woff2'), url('fonts/source-code-pro.woff') format('woff');
+	font-weight: normal;
+	font-style: normal;
+}
+
+@font-face{
+	font-family: "Source Code Pro";
+	src: local('Source Code Pro'), url('../fonts/source-code-pro-bold.woff2') format('woff2'), url('fonts/source-code-pro-bold.woff') format('woff');
+	font-weight: bold;
+	font-style: normal;
+}
+
+@font-face{
+	font-family: "Source Code Pro";
+	src: local('Source Code Pro'), url('../fonts/source-code-pro-italic.woff2') format('woff2'), url('fonts/source-code-pro-italic.woff') format('woff');
+	font-weight: normal;
+	font-style: italic;
+}
+
+@font-face{
+	font-family: "Source Code Pro";
+	src: local('Source Code Pro'), url('../fonts/source-code-pro-bold-italic.woff2') format('woff2'), url('fonts/source-code-pro-bold-italic.woff') format('woff');
 	font-weight: bold;
 	font-style: italic;
 }


### PR DESCRIPTION
This is a weird one - I’m running nightly Firefox and beta macOS so it’s probably a problem there, but the downloadable Source Code Pro will only render in black. By adding a local reference first it uses the locally installed versions of the font which render fine for me. I’ve checked and I’m on the latest released Source Code Pro locally (2.030); I don’t know what version the hosted fonts are. Either way, I don’t see a particular problem in referencing local fonts, unless you’re relying on new features not present in the old versions of the fonts people might have installed.

The problem is the same on the normal standardebooks.org as well. It didn’t show up until after I installed the macOS 10.14 beta, but it may have been a difference in Firefox at the same time, or exposed a latent bug there.