### PR TITLE
Rearrange glossary paragraphs

### DIFF
--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -1314,6 +1314,8 @@ Glossary entries
 
 #.	The :html:`<dt>` element contains a single :html:`<dfn>` element, which in turn contains the term to be defined.
 
+#.	The :html:`<dd>` element has :html:`epub:type="glossdef"`.
+
 #.	A :html:`<dd>` element appears after one or more :html:`<dt>` elements, and contains the definition for the preceding :html:`<dt>` element(s). It must contain at least one block-level child, usually :html:`<p>`.
 
 	.. code:: html
@@ -1338,6 +1340,3 @@ Glossary entries
 		<dd epub:type="glossdef">
 			<p>Plants in which the inflorescence consists of numerous small flowers (florets) brought together into a dense head, the base of which is enclosed by a common envelope. (Examples, the Daisy, Dandelion, <abbr class="eoc">etc.</abbr>)</p>
 		</dd>
-
-#.	The :html:`<dd>` element has :html:`epub:type="glossdef"`.
-


### PR DESCRIPTION
I should have done this yesterday, but it's a little more subjective. If you don't want it, no problem, but here's my logic.

Current order:
1. "`dl` consists of `dd` and `dt`."
2. "`dt` has epub type…"
3. Detail on `dt`.
4. Detail on `dd`, with an example of both `dt`/`dt`.
5. More detail on `dt`, with another example.
6. "`dd` has epub type…"

That last "`dd` has epub type" seems out of place, and comes after the examples showing it instead of before like `dt`. Moving that last paragraph up keeps the same rhythm of the first two paragraphs ("here's `X`'s epub type, here are details about `X`").

1. "`dl` consists of `dd` and `dt`."
2. "`dt` has epub type…"
3. Detail on `dt`.
4. "`dd` has epub type…"
5. Detail on `dd`, with an example of both `dt`/`dt`.
6. More detail on `dt`, with another example.
