### PR TITLE
Headers

### DIFF
--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -62,7 +62,7 @@ Book 1, Part 2, Chapter 3 (:path:`chapter-1-2-3.xhtml`):
 
 	<section id="book-1" epub:type="division">
 		<section id="part-1-2" epub:type="part">
-			<section id="chapter-3" epub:type="chapter">
+			<section id="chapter-1-2-3" epub:type="chapter">
 				<h4><span epub:type="label">Chapter</span> <span epub:type="ordinal z3998:roman">III</span></h4>
 				<p>...</p>
 				<p>...</p>

--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -52,7 +52,7 @@ Book 1, Part 2 (:path:`part-1-2.xhtml`):
 
 	<section id="book-1" epub:type="division">
 		<section id="part-1-2" epub:type="part">
-			<h2><span epub:type="label">Part</span> <span epub:type="ordinal z3998:roman">II</span></h2>
+			<h3><span epub:type="label">Part</span> <span epub:type="ordinal z3998:roman">II</span></h3>
 		</section>
 	</section>
 
@@ -63,7 +63,7 @@ Book 1, Part 2, Chapter 3 (:path:`chapter-1-2-3.xhtml`):
 	<section id="book-1" epub:type="division">
 		<section id="part-1-2" epub:type="part">
 			<section id="chapter-3" epub:type="chapter">
-				<h2><span epub:type="label">Chapter</span> <span epub:type="ordinal z3998:roman">III</span></h2>
+				<h4><span epub:type="label">Chapter</span> <span epub:type="ordinal z3998:roman">III</span></h4>
 				<p>...</p>
 				<p>...</p>
 			</section>


### PR DESCRIPTION
The sections 7.1.4.2 and 7.2.4 provide conflicting information about which h tag should be used in books with subdivisions.

Also the chapter id seems to be wrong in 7.1.4.2 but I'm not sure if there's some rule I'm missing here.

