### PR TITLE
Merge drama table CSS blocks

### DIFF
--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -697,6 +697,7 @@ Plays and drama
 		[epub|type~="z3998:drama"],
 		[epub|type~="z3998:drama"] table{
 			border-collapse: collapse;
+			margin: 1em auto;
 		}
 
 		[epub|type~="z3998:drama"] tr:first-child td{
@@ -725,11 +726,6 @@ Plays and drama
 			-epub-hyphens: none;
 			text-align: right;
 			width: 20%;
-		}
-
-		table[epub|type~="z3998:drama"],
-		[epub|type~="z3998:drama"] table{
-			margin: 1em auto;
 		}
 
 		[epub|type~="z3998:stage-direction"]{


### PR DESCRIPTION
We have two nearly identical selectors. As `border-collapse: collapse` in the first will only apply to tables, we can just copy the `margin` declaration from the second into the first and remove that block.