### PR TITLE
Fix tabulation and other bugs with make_one_page function

### DIFF
--- a/build-manual.py
+++ b/build-manual.py
@@ -106,9 +106,14 @@ def make_one_page(dest_directory, header_html: str, footer_html: str):
 
 	for file in php_files:
 		with open(dest_directory / file, "r", encoding="utf-8") as file:
-			soup = BeautifulSoup(file, features="html.parser")
+			section_text = file.read()
 
-		bodymatter.append(soup.find_all("section")[0])
+			# Remove everything before and after top level section
+			section_text = section_text[section_text.find("<section"):]
+			section_text = section_text[:section_text.rfind("</section>")]
+			section_text += "</section>"
+
+			bodymatter.append(section_text)
 
 	# Writing the one page manual php file (overwrites if exist)
 	with open(dest_directory / "single-page.php", "w+", encoding="utf-8") as file:


### PR DESCRIPTION
For whatever reason, BeautifulSoup doesn't extract everything character by character. This makes the recently added single page version of the manual have a few errors.

1. It removed tabs before tags (none of the code samples were tabulated correctly)
2. It removed empty lines (again, the code samples suffer)
3. The urls in 10.3.3.6.3 were also screwed up because they included the PD_YEAR variable. It would make it so it wasn't substituted correctly and so the links look like this: https://www.google.com/webhp?tbs=cdr:1,cd_min:,cd_max:%3C?=%20PD_YEAR%20?%3E&amp;tbm=bks

There's probably some way to tell BeautifulSoup to not be too smart for its own good and just take everything character by character, but I couldn't find how.