### PR TITLE
Clarify a couple of points

### DIFF
--- a/8-typography.rst
+++ b/8-typography.rst
@@ -159,7 +159,7 @@ Italicizing non-English words and phrases
 
 #.	If certain non-English words are used so frequently in the text that italicizing them at each instance would be distracting to the reader, then only the first instance is italicized. Subsequent instances are wrapped in a :html:`<span xml:lang="LANGUAGE">` element.
 
-#.	Words and phrases that are originally non-English in origin, but that can now be found in `Merriam-Webster <https://www.merriam-webster.com>`__, are not italicized, even if they are in the source.
+#.	Words and phrases that are originally non-English in origin, but that can now be found in `Merriam-Webster <https://www.merriam-webster.com>`__, are not italicized.
 
 	.. code:: html
 

--- a/8-typography.rst
+++ b/8-typography.rst
@@ -159,7 +159,7 @@ Italicizing non-English words and phrases
 
 #.	If certain non-English words are used so frequently in the text that italicizing them at each instance would be distracting to the reader, then only the first instance is italicized. Subsequent instances are wrapped in a :html:`<span xml:lang="LANGUAGE">` element.
 
-#.	Words and phrases that are originally non-English in origin, but that can now be found in `Merriam-Webster <https://www.merriam-webster.com>`__, are not italicized.
+#.	Words and phrases that are originally non-English in origin, but that can now be found in `Merriam-Webster <https://www.merriam-webster.com>`__, are not italicized, even if they are in the source.
 
 	.. code:: html
 
@@ -773,7 +773,7 @@ Roman numerals
 
 #.	Roman numerals are not followed by trailing periods, except for grammatical reasons.
 
-#.	Roman numerals are set using ASCII, not the Unicode Roman numeral glyphs.
+#.	Roman numerals are set using uppercase ASCII, not the Unicode Roman numeral glyphs.
 
 #.	Roman numerals are not followed by ordinal indicators.
 


### PR DESCRIPTION
A couple of things come up pretty regularly on the list and in reviews.
1. Roman numerals should be uppercased.
2. Non-English words in M-W should not be italicized, _even if they are in the source._

In the first case, the manual doesn't address it at all. In the second, it does say they shouldn't be italicized, but for some reason people seem to think it doesn't apply if it's italicized in the source.

This just attempts to clarify both points.