### PR TITLE
Correct warning for non-breaking hyphens

### DIFF
--- a/8-typography.rst
+++ b/8-typography.rst
@@ -649,7 +649,7 @@ There are many kinds of dashes, and the run-of-the-mill hyphen is often not the 
 
 	.. warning::
 
-		When adding non-breaking hyphens for obscured letters, beware that :bash:`se typogrify` will incorrectly convert them to regular hyphens!
+		When adding non-breaking hyphens to stretch out words, beware that :bash:`se typogrify` will incorrectly convert them to regular hyphens!
 
 Em-dashes
 ---------


### PR DESCRIPTION
8.7.7.6 details how non-breaking hyphens can be used to stretch out a word. It contains a warning that non-breaking hyphens for obscured letters will be replaced with regular hyphens by typogrify. It is a duplicate of the warning from 8.7.7.8.3, and should refer to stretched out words instead of obscured letter.