### PR TITLE
Add rules for image IDs

### DIFF
--- a/2-filesystem.rst
+++ b/2-filesystem.rst
@@ -132,6 +132,8 @@ XHTML file naming conventions
 		The work’s second preface, titled “Preface to the Charles Dickens Edition”      :path:`preface-2.xhtml`
 		=============================================================================== =============================
 
+#. If a work contains images other than the cover art, the filename of each image should be :value:`illustration-` followed by :path:`-N`, where :path:`N` is a number representing the image’s order of appearance in the work, starting at :path:`1`.
+
 The :path:`se-lint-ignore.xml` file
 ***********************************
 

--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -472,6 +472,7 @@ Epigraphs in section headers
 	.. code:: css
 
 		/* Epigraphs in section headers */
+		article > header [epub|type~="epigraph"],
 		section > header [epub|type~="epigraph"]{
 			display: inline-block;
 			margin: auto;
@@ -479,11 +480,13 @@ Epigraphs in section headers
 			text-align: initial;
 		}
 
+		article > header [epub|type~="epigraph"] + *,
 		section > header [epub|type~="epigraph"] + *{
 			margin-top: 3em;
 		}
 
 		@supports(display: table){
+			article > header [epub|type~="epigraph"],
 			section > header [epub|type~="epigraph"]{
 				display: table;
 			}

--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -1166,6 +1166,23 @@ Examples
 Images
 ******
 
+#.	:html:`<img>` Each image has a unique :html:`id` attribute.
+
+    #.  That attribute's name is :value:`illustration-` followed by :value:`-N`, where :value:`N` is the sequence number of the element starting at :value:`1`.
+
+    #.  If the image is inline with the text, the :html:`id` is on the :html:`<img>` element.
+
+			.. code:: html
+
+				<img alt="..." src="..." id="illustration-1" />
+
+	#.	When contained in a :html:`<figure>` element, the :html:`<img>` element does not have an :html:`id` attribute; instead the :html:`<figure>` element has the :html:`id` attribute.
+
+			.. code:: html
+
+                <figure id="illustration-3">
+    				<img alt="..." src="..." />
+
 #.	:html:`<img>` elements have an :html:`alt` attribute that uses prose to describe the image in detail; this is what screen reading software will read aloud.
 
 	#.	The :html:`alt` attribute describes the visual image itself in words, which is not the same as writing a caption or describing its place in the book.
@@ -1199,8 +1216,6 @@ Images
 #.	:html:`<img>` element whose image is black-on-white line art (i.e. exactly two colors, **not** grayscale!) are PNG files with a transparent background. They have the :value:`se:image.color-depth.black-on-transparent` semantic inflection.
 
 #.	:html:`<img>` elements that are meant to be aligned on the block level or displayed as full-page images are contained in a parent :html:`<figure>` element, with an optional :html:`<figcaption>` sibling.
-
-	#.	When contained in a :html:`<figure>` element, the :html:`<img>` element does not have an :html:`id` attribute; instead the :html:`<figure>` element has the :html:`id` attribute.
 
 	#.	An optional :html:`<figcaption>` element containing  a concise context-dependent caption may follow the :html:`<img>` element within a :html:`<figure>` element. This caption depends on the surrounding context, and is not necessarily (or even ideally) identical to the :html:`<img>` element’s :html:`alt` attribute.
 

--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -1229,12 +1229,24 @@ Images
 		.. code:: css
 
 			figure.full-page{
+				break-after: page;
+				break-before: page;
+				break-inside: avoid;
 				margin: 0;
 				max-height: 100%;
-				break-before: page;
-				break-after: page;
-				break-inside: avoid;
 				text-align: center;
+			}
+
+			@supports(display: flex) and (max-height: 100vh){
+				figure.full-page{
+					display: flex;
+					flex-direction: column;
+					max-height: 100vh;
+				}
+
+				figure.full-page img{
+					height: 100%;
+				}
 			}
 
 	#.	:html:`<figure>` elements that meant to be aligned block-level with the text have this additional CSS:

--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -1320,14 +1320,14 @@ Examples
 .. code:: html
 
 	<p>...</p>
-	<figure class="full-page" id="image-11">
+	<figure class="full-page" id="illustration-11">
 		<img alt="A massive whale breaching the water, with a sailor floating in the water directly within the whale’s mouth." src="../images/illustration-11.jpg" epub:type="z3998:illustration"/>
 		<figcaption>The Whale eats Sailor Jim.</figcaption>
 	</figure>
 
 .. code:: html
 
-	<p>He saw strange alien text that looked like this: <img alt="A line of alien heiroglyphs." src="../images/alien-text.svg" epub:type="z3998:illustration se:color-depth.black-on-transparent" />. There was nothing else amongst the ruins.</p>
+	<p>He saw strange alien text that looked like this: <img alt="A line of alien heiroglyphs." src="../images/illustration-2.svg" epub:type="z3998:illustration se:color-depth.black-on-transparent" />. There was nothing else amongst the ruins.</p>
 
 List of Illustrations (the LoI)
 *******************************

--- a/8-typography.rst
+++ b/8-typography.rst
@@ -627,19 +627,19 @@ There are many kinds of dashes, and the run-of-the-mill hyphen is often not the 
 
 		<p>5 − 2 = 3</p>
 
-#.	En-dashes (:utf:`–` or U+2013) are used to indicate a numerical or date range; to indicate a relationships where two concepts are connected by the word “to,” for example a distance between locations or a range between numbers; or to indicate a connection in location between two places.
+#.	En-dashes (:utf:`–` or U+2013) are used to indicate a numeric or date range; to indicate a relationships where two concepts are connected by the word “to,” for example a distance between locations or a range between numbers; or to indicate a connection in location between two places. En-dashes are preceded and followed by the invisible word joiner glyph (U+2060).
 
 	.. code:: html
 
-		<p>We talked 2–3 days ago.</p>
+		<p>We talked 2:ws:`wj`–:ws:`wj`3 days ago.</p>
 
 	.. code:: html
 
-		<p>We took the Berlin–Munich train yesterday.</p>
+		<p>We took the Berlin:ws:`wj`–:ws:`wj`Munich train yesterday.</p>
 
 	.. code:: html
 
-		<p>I saw the torpedo-boat in the Ems⁠–⁠Jade Canal.</p>
+		<p>I saw the torpedo-boat in the Ems⁠:ws:`wj`–:ws:`wj`⁠Jade Canal.</p>
 
 #.	Non-break hyphens (:utf:`‑` or U+2011) are used when a single word is stretched out by a speaker for prosaic effect.
 

--- a/8-typography.rst
+++ b/8-typography.rst
@@ -1136,7 +1136,7 @@ Math
 					</m:math>
 				</p>
 
-	#.	If a MathML variable includes an overline, it is set by combining the variable’s normal Unicode glyph and the Unicode overline glyph (:utf:`‾` or U+203E) in a :html:`<m:mover>` element. However in the :html:`alttext` attribute, the Unicode overline combining mark (U+0305) is used to represent the overline in Unicode.
+	#.	If a MathML variable includes an overline, it is set by combining the variable’s normal Unicode glyph and the Unicode overline glyph, :utf:`‾` (U+203E), in a :html:`<m:mover>` element. However in the :html:`alttext` attribute, the Unicode combining overline, :utf:`◌̅` (U+0305), is used to represent the overline in Unicode.
 
 		.. class:: corrected
 
@@ -1462,11 +1462,17 @@ Scansion
 
 Scansion is the representation of the metrical stresses in lines of verse.
 
-#.	:utf:`×` (U+00d7) indicates an unstressed sylllable and :utf:`/` (U+002f) indicates a stressed syllable. They are separated from each other with no-break spaces (U+00A0).
+#.	When scansion marks are next to, instead of above, letters, :utf:`×` (U+00d7) indicates an unstressed sylllable and :utf:`/` (U+002f) indicates a stressed syllable. They are separated from each other with no-break spaces (U+00A0).
 
 	.. code:: html
 
 		<p>Several of his types, however, constantly occur; <abbr>e.g.</abbr> A and a variant (/ × | / ×) (/ × × | / ×); B and a variant (× / | × /) (× × / | × /); a variant of D (/ × | / × ×); E (/ × × | /). </p>
+
+#.	When scansion marks are above letters, a combining breve, :utf:`◌̆` (U+0306), is used to indicate an unstressed syllable and a combining vertical line above, :utf:`◌̍` (U+030D), is used to indicate a stressed syllable. Vertical lines are always above letters, not next to them. Indicating unstressed symbols is optional.
+
+	.. code:: html
+
+		<p>I̍f wĕ sha̍dŏws ha̍ve ŏffe̍ndĕd, / Thi̍nk bŭt thi̍s ănd a̍ll ĭs me̍ndĕd.</p>
 
 #.	Lines of poetry listed on a single line (like in a quotation) are separated by a space, then a forward slash, then a space. Capitalization is preserved for each line.
 


### PR DESCRIPTION
I added them at the beginning of the Images section; it was a toss-up where they should go, I just picked a place. I moved the existing rule related to `id` (on `figure` if present rather than `img`) to this section, so all the `id` information would be together.