### PR TITLE
Fix wrong signature style in selector example

### DIFF
--- a/1-code-style.rst
+++ b/1-code-style.rst
@@ -190,7 +190,7 @@ Selectors
 
 		.. code:: css
 
-			abbr.era, [epub|type~="z3998:signature"]{
+			abbr.era, abbr.temperature{
 				font-variant: all-small-caps;
 			}
 
@@ -200,7 +200,7 @@ Selectors
 		.. code:: css
 
 			abbr.era,
-			[epub|type~="z3998:signature"]{
+			abbr.temperature{
 				font-variant: all-small-caps;
 			}
 

--- a/8-typography.rst
+++ b/8-typography.rst
@@ -1437,7 +1437,7 @@ Temperatures
 Abbreviated units of temperature
 ================================
 
-#.	Units of temperature measurement, like Farenheit or Celcius, may be abbreviated to :string:`F` or :string:`C`.
+#.	Units of temperature measurement, like Farenheit or Celsius, may be abbreviated to :string:`F` or :string:`C`.
 
 #.	Units of temperature measurement do not have trailing periods.
 


### PR DESCRIPTION
Although this is just an example for selector ordering, the correct way should be correct styling. Signatures aren’t all-small-caps but small-caps.

(Also a mini spelling fix.)