### PR TITLE
5: Fix comment on th scope

### DIFF
--- a/5-general-xhtml-and-css-patterns.rst
+++ b/5-general-xhtml-and-css-patterns.rst
@@ -298,7 +298,7 @@ Tables
 
 	#.	:html:`<th>` elements are used in :html:`<thead>` elements, instead of :html:`<td>`.
 
-	#.	:html:`<th>` elements only appear in :html:`<thead>` elements, unless they contain the :html:`scope` attribute set to either :value:`row` or :value:`rowspan`. The :html:`scope` attribute set to those values may be used to semantically identify a table header which applies to a horizontal row instead of a vertical column.
+	#.	:html:`<th>` elements only appear in :html:`<thead>` elements, unless they contain the :html:`scope` attribute set to either :value:`row` or :value:`rowgroup`. The :html:`scope` attribute set to those values may be used to semantically identify a table header which applies to a horizontal row instead of a vertical column.
 
 #.	:html:`<table>` elements that are used to display tabular numerical data, for example columns of sums, have CSS styling for tabular numbers: :css:`{ font-variant-numeric: tabular-nums; }`.
 


### PR DESCRIPTION
The correct value for `scope` is `rowgroup` and not `rowspan`: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th