### PR TITLE
Don’t hyphenate “em dash” and “en dash”

### DIFF
--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -449,7 +449,7 @@ Epigraphs
 Epigraphs in section headers
 ============================
 
-#.	Epigraphs in section headers have the quote source in a :html:`<cite>` element set in small caps, without a leading em-dash and without a trailing period.
+#.	Epigraphs in section headers have the quote source in a :html:`<cite>` element set in small caps, without a leading em dash and without a trailing period.
 
 	.. class:: wrong
 
@@ -1470,7 +1470,7 @@ Individual endnotes
 
 	#.	In endnotes where the last block-level element is verse, quotation, or otherwise not plain prose text, the backlink goes in its own :html:`<p>` element following the last block-level element in the endnote.
 
-#.	Endnotes with ending citations have those citations are wrapped in a :html:`<cite>` element, including any em-dashes. A space follows the :html:`<cite>` element, before the backlink.
+#.	Endnotes with ending citations have those citations are wrapped in a :html:`<cite>` element, including any em dashes. A space follows the :html:`<cite>` element, before the backlink.
 
 .. class:: no-numbering
 

--- a/8-typography.rst
+++ b/8-typography.rst
@@ -450,7 +450,7 @@ Headers
 Chapter headers
 ===============
 
-#.	Epigraphs in chapters have the quote source set in small caps, without a leading em-dash and without a trailing period.
+#.	Epigraphs in chapters have the quote source set in small caps, without a leading em dash and without a trailing period.
 
 	.. class:: wrong
 
@@ -646,7 +646,7 @@ There are many kinds of dashes, and the run-of-the-mill hyphen is often not the 
 
 		<p>5 − 2 = 3</p>
 
-#.	En-dashes (:utf:`–` or U+2013) are used to indicate a numeric or date range; to indicate a relationships where two concepts are connected by the word “to,” for example a distance between locations or a range between numbers; or to indicate a connection in location between two places. En-dashes are preceded and followed by the invisible word joiner glyph (U+2060).
+#.	En dashes (:utf:`–` or U+2013) are used to indicate a numeric or date range; to indicate a relationships where two concepts are connected by the word “to,” for example a distance between locations or a range between numbers; or to indicate a connection in location between two places. En dashes are preceded and followed by the invisible word joiner glyph (U+2060).
 
 	.. code:: html
 
@@ -670,14 +670,14 @@ There are many kinds of dashes, and the run-of-the-mill hyphen is often not the 
 
 		When adding non-breaking hyphens to stretch out words, beware that :bash:`se typogrify` will incorrectly convert them to regular hyphens!
 
-Em-dashes
+Em dashes
 ---------
 
-Em-dashes (:utf:`—` or U+2014) are typically used to offset parenthetical phrases.
+Em dashes (:utf:`—` or U+2014) are typically used to offset parenthetical phrases.
 
-#.	Em-dashes are preceded by the invisible word joiner glyph (U+2060).
+#.	Em dashes are preceded by the invisible word joiner glyph (U+2060).
 
-#.	Interruption in dialog is set by a single em-dash, not two em-dashes or a two-em-dash.
+#.	Interruption in dialog is set by a single em dash, not two em dashes or a two-em dash.
 
 	.. class:: wrong
 
@@ -694,7 +694,7 @@ Em-dashes (:utf:`—` or U+2014) are typically used to offset parenthetical phra
 Partially-obscured words
 ------------------------
 
-#.	Em-dashes are used for partially-obscured years.
+#.	Em dashes are used for partially-obscured years.
 
 	.. code:: html
 
@@ -716,13 +716,13 @@ Partially-obscured words
 
 		When adding non-breaking hyphens for obscured letters, beware that :bash:`se typogrify` will incorrectly convert them to regular hyphens!
 
-#.	A two-em-dash (:utf:`⸺` or U+2E3A) preceded by a word joiner glyph (U+2060) is used in *partially* obscured word.
+#.	A two-em dash (:utf:`⸺` or U+2E3A) preceded by a word joiner glyph (U+2060) is used in *partially* obscured word.
 
 	.. code:: html
 
 		<p>Sally J:ws:`wj`⸺ walked through town.</p>
 
-#.	A three-em-dash (:utf:`⸻` or U+2E3B) is used for *completely* obscured words.
+#.	A three-em dash (:utf:`⸻` or U+2E3B) is used for *completely* obscured words.
 
 	.. code:: html
 
@@ -1649,7 +1649,7 @@ Verses and Chapters of the Bible
 
 			<p>“In the beginning God created the heaven and the earth” is the first verse of Genesis 1.</p>
 
-#.	If a continuous range of verses is being cited, an en-dash (:utf:`–` or U+2013) is placed between the verse numbers indicating the beginning and the end of the range.
+#.	If a continuous range of verses is being cited, an en dash (:utf:`–` or U+2013) is placed between the verse numbers indicating the beginning and the end of the range.
 
 	.. code:: html
 

--- a/9-metadata.rst
+++ b/9-metadata.rst
@@ -252,7 +252,7 @@ The :html:`<dc:description>` element contains a short, single-sentence summary o
 
 #.	For collections, compilations, and omnibuses, a sentence fragment is acceptable as a description.
 
-#.	The description is typogrified, i.e. it contains Unicode curly quotes, em-dashes, and the like.
+#.	The description is typogrified, i.e. it contains Unicode curly quotes, em dashes, and the like.
 
 The long description
 =====================
@@ -261,7 +261,7 @@ The :html:`<meta property="se:long-description">` element contains a much longer
 
 #.	The long description is a non-biased, encyclopedia-like description of the book, including any relevant publication history, backstory, or historical notes. It is as detailed as possible without giving away plot spoilers. It does not impart the producer’s opinions of the book, or include content warnings. Think along the lines of a Wikipedia-like summary of the book and its history, *but under no circumstances can a producer copy and paste from Wikipedia!* (Wikipedia licenses articles under a CC license which is incompatible with Standard Ebooks’ CC0 public domain dedication.)
 
-#.	The long description is typogrified, i.e. it contains Unicode curly quotes, em-dashes, and the like.
+#.	The long description is typogrified, i.e. it contains Unicode curly quotes, em dashes, and the like.
 
 #.	The long description is in *escaped* HTML, with the HTML beginning on its own line after the :html:`<meta property="se:long-description">` element.
 


### PR DESCRIPTION
The manual uses both “en-dash”/“em-dash” and “en dash”/“em dash.”

Since neither Wikipedia nor Merriam-Webster hyphenate them, I standardized on space (including “two-em dash” and “three-em dash”).