### PR TITLE
Clarify that z3888:given-name should be used for middle names as well

### DIFF
--- a/8-typography.rst
+++ b/8-typography.rst
@@ -1316,11 +1316,13 @@ Initials and abbreviations
 
 		<p>His favorite hobby was <abbr epub:type="z3998:acronym">SCUBA</abbr>.</p>
 
-#.	Initials of people’s names are each separated by periods and spaces. The group of initials is wrapped in an :html:`<abbr epub:type="z3998:*-name">` element. The correct semantic is selected from :value:`z3998:personal-name` (a complete personal name including last name), :value:`z3998:given-name` (a person's given, or first, name(s)), or :value:`z3998:surname` (a person's last name).
+#.	Initials of people’s names are each separated by periods and spaces. The group of initials is wrapped in an :html:`<abbr epub:type="z3998:*-name">` element. The correct semantic is selected from :value:`z3998:personal-name` (a complete personal name including last name), :value:`z3998:given-name` (a person's given, or first, name(s), and/or middle name), or :value:`z3998:surname` (a person's last name).
 
 	.. code:: html
 
 		<p><abbr epub:type="z3998:given-name">H. P.</abbr> Lovecraft described himself as an aged antiquarian.</p>
+
+		<p>William <abbr epub:type="z3998:given-name">H.</abbr> Taft was our twenty-seventh president.</p>
 
 		<footer>
 			<p epub:type="z3998:signature"><abbr epub:type="z3998:personal-name">A. A. C.</abbr></p>


### PR DESCRIPTION
As you saw, this already came up on the list. I think most people think "given" refers to first name (and this is what our text said as well), so they're not going to immediately get that given-name should be used when it's _only_ the middle initial. This is an attempt to clarify, and add an example with just middle initial as well.