### PR TITLE
Add need for roman semantic in Roman numeral section, remove it from ToC

### DIFF
--- a/6-standard-ebooks-section-patterns.rst
+++ b/6-standard-ebooks-section-patterns.rst
@@ -109,7 +109,7 @@ The :html:`<nav>` element’s top-level :html:`<ol>` element contains a list of 
 							<a href="text/chapter-1-1.xhtml" epub:type="z3998:roman">I</a>
 						</li>
 
-#.	Roman numerals in the ToC have the semantic inflection of :value:`z3998:roman`. A :html:`<span>` element is included if the entire contents of the :html:`<a>` element are not a Roman numeral.
+#.	Roman numerals in the ToC have a :html:`<span>` element if the entire contents of the :html:`<a>` element are not a Roman numeral.
 
 	.. class:: wrong
 

--- a/8-typography.rst
+++ b/8-typography.rst
@@ -834,9 +834,11 @@ Numbers, measurements, and math
 Roman numerals
 ==============
 
-#.	Roman numerals are not followed by trailing periods, except for grammatical reasons.
-
 #.	Roman numerals are set using uppercase ASCII, not the Unicode Roman numeral glyphs.
+
+#.	Roman numerals have the semantic inflection of :value:`z3998:roman`.
+
+#.	Roman numerals are not followed by trailing periods, except for grammatical reasons.
 
 #.	Roman numerals are not followed by ordinal indicators.
 


### PR DESCRIPTION
You, from a discussion a couple of weeks ago re the manual and tagging roman numerals:
>It should probably be the other way around--it should state to tag them in the section about Roman, but not really in the section about headers because (though it should be in the examples)

This does that. (You didn't finish that "because…" but I didn't think it would affect the outcome. :) )
I also reordered the elements in the Roman numeral section to put the positives first, and then the negatives; that way the semantic is indicated before the negative example that includes the semantic.