### PR TITLE
Remove duplicate break-inside rules

### DIFF
--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -1267,7 +1267,6 @@ Images
 			figure.full-page{
 				break-after: page;
 				break-before: page;
-				break-inside: avoid;
 				margin: 0;
 				max-height: 100vh;
 				text-align: center;
@@ -1290,7 +1289,6 @@ Images
 		.. code:: css
 
 			figure{
-				break-inside: avoid;
 				margin: 1em auto;
 				text-align: center;
 			}


### PR DESCRIPTION
We always have `break-inside: avoid` in the default figure CSS (https://standardebooks.org/manual/1.6.2/single-page#7.8.5.2) so we don’t need to redeclare it for full-page and block-level figures.