### PR TITLE
Remove duplicated Finnish National Gallery link

### DIFF
--- a/10-art-and-images.rst
+++ b/10-art-and-images.rst
@@ -198,8 +198,6 @@ Images that are explicitly marked as CC0 from these museums can be used without 
 
 -	`Rijksmuseum <https://www.rijksmuseum.nl/en/search?q=&f=1&p=1&ps=12&type=painting&imgonly=True&st=Objects>`__ (Open the “Object Data” section and check the “Copyright” entry under the “Acquisition and right” section to confirm CC0)
 
--	`Finnish National Gallery via Europeana <https://www.europeana.eu/portal/en/collections/art?f%5BDATA_PROVIDER%5D%5B%5D=Finnish+National+Gallery&f%5BREUSABILITY%5D%5B%5D=open&f%5BRIGHTS%5D%5B%5D=http%2A%3A%2F%2Fcreativecommons.org%2F%2Apublicdomain%2Fzero%2A&per_page=96&view=grid>`__ (Use the “View at” link under the “Find out more” header to confirm CC0 license at the museum’s site)
-
 -	`Met Museum <https://www.metmuseum.org/art/collection/search#!/search?material=Paintings&showOnly=withImage%7Copenaccess&sortBy=Relevance&sortOrder=asc&perPage=20&offset=0&pageSize=0>`__ (CC0 items have the CC0 logo under the image)
 
 -	`National Museum Sweden <https://www.nationalmuseum.se/en/samlingarna/fria-bilder>`__ (CC-PD items have the CC-PD mark in the lower left of the item’s detail view)


### PR DESCRIPTION
1. This link isn't linking to anything specific specific on Europeana right now.
2. We already have a link to the Finnish National Gallery's collection, so this seems like a duplicate.