### PR TITLE
Add RISD and Aberdeen as cleared CC0 sources

### DIFF
--- a/10-art-and-images.rst
+++ b/10-art-and-images.rst
@@ -230,6 +230,8 @@ Images that are explicitly marked as CC0 from these museums can be used without 
 
 -	`RISD Museum <https://risdmuseum.org/art-design/collection>`__ (CC0 items have a link to the CC0 license in the “Use” section.)
 
+-	`Aberdeen Archives, Gallery & Museums <https://emuseum.aberdeencity.gov.uk/collections/102307/open-access-images--fine-art>`__ (CC0 items say “Out of copyright - CC0” on the copyright line.)
+
 Clearance FAQ
 ~~~~~~~~~~~~~
 

--- a/10-art-and-images.rst
+++ b/10-art-and-images.rst
@@ -228,6 +228,8 @@ Images that are explicitly marked as CC0 from these museums can be used without 
 
 -	`Nivaagaards Malerisamling <https://www.nivaagaard.dk/en/samling/>`__ (CC0 items say “Public Domain” by the picture, which leads to a license details page, which links to a CC0 license.)
 
+-	`RISD Museum <https://risdmuseum.org/art-design/collection>`__ (CC0 items have a link to the CC0 license in the “Use” section.)
+
 Clearance FAQ
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
It seems the RISD Museum was already cleared as a CC0 source [in 2019](https://groups.google.com/g/standardebooks/c/DrEkcPaqkko/m/xy8sKBjAAQAJl). The CC0 license is still present for the PD works and as far as I can tell nothing has changed. If this is still clear it would be great to add to the manual.