### PR TITLE
Correct ordinal usage in examples

### DIFF
--- a/4-semantics.rst
+++ b/4-semantics.rst
@@ -147,11 +147,11 @@ For example, an ebook producer may want to convey that the contents of a certain
 
 		<body epub:type="z3998:non-fiction">
 			<section id="chapter-1" epub:type="chapter">
-				<h2 epub:type="title z3998:roman">I</h2>
+				<h2 epub:type="ordinal z3998:roman">I</h2>
 				...
 			</section>
 			<section id="chapter-2" epub:type="chapter">
-				<h2 epub:type="title z3998:roman">II</h2>
+				<h2 epub:type="ordinal z3998:roman">II</h2>
 				...
 			</section>
 		</body>

--- a/8-typography.rst
+++ b/8-typography.rst
@@ -471,7 +471,7 @@ Chapter headers
 		.. code:: html
 
 			<header>
-				<h2 epub:type="title z3998:roman">II</h2>
+				<h2 epub:type="ordinal z3998:roman">II</h2>
 				<blockquote epub:type="epigraph">
 					<p>“Desire no more than to thy lot may fall. …”</p>
 					<cite>—Chaucer.</cite>
@@ -489,7 +489,7 @@ Chapter headers
 		.. code:: html
 
 			<header>
-				<h2 epub:type="title z3998:roman">II</h2>
+				<h2 epub:type="ordinal z3998:roman">II</h2>
 				<blockquote epub:type="epigraph">
 					<p>“Desire no more than to thy lot may fall. …”</p>
 					<cite>Chaucer</cite>


### PR DESCRIPTION
We use `ordinal` correctly in 8.1.4, but use `title` incorrectly in a couple of other examples.