### PR TITLE
Update epub semantics link

### DIFF
--- a/4-semantics.rst
+++ b/4-semantics.rst
@@ -105,7 +105,7 @@ Inline elements are by default rendered with :css:`display: inline;`. See the `c
 Semantic Inflection
 *******************
 
-The epub spec allows for `semantic inflection <https://idpf.github.io/epub-vocabs/structure/>`__, which is a way of adding semantic metadata to elements in the ebook document.
+The epub spec allows for `semantic inflection <https://www.w3.org/TR/epub-ssv-11/>`__, which is a way of adding semantic metadata to elements in the ebook document.
 
 For example, an ebook producer may want to convey that the contents of a certain :html:`<section>` are part of a chapter. They would do that by using the :html:`epub:type` attribute:
 
@@ -113,7 +113,7 @@ For example, an ebook producer may want to convey that the contents of a certain
 
 	<section epub:type="chapter">...</section>
 
-#.	The epub spec includes a `vocabulary <https://idpf.github.io/epub-vocabs/structure/>`__ that can be used in the :html:`epub:type` attribute. This vocabulary has priority when selecting a semantic keyword, even if other vocabularies contain the same one.
+#.	The epub spec includes a `vocabulary <https://www.w3.org/TR/epub-ssv-11/>`__ that can be used in the :html:`epub:type` attribute. This vocabulary has priority when selecting a semantic keyword, even if other vocabularies contain the same one.
 
 #.	The epub spec might not contain a keyword necessary to describe the semantics of a particular element. In that case, the `z3998 vocabulary <http://www.daisy.org/z3998/2012/vocab/structure/>`__ is consulted next.
 

--- a/6-standard-ebooks-section-patterns.rst
+++ b/6-standard-ebooks-section-patterns.rst
@@ -149,7 +149,7 @@ The :html:`<nav>` element’s top-level :html:`<ol>` element contains a list of 
 :html:`<a>` descendents
 -----------------------
 
-#.	The :value:`title`, :value:`subtitle`, :value:`ordinal`, and any `related title epub semantics <https://idpf.github.io/epub-vocabs/structure/#titles>`__ are not included in ToC entries. Their usage context is only within actual heading content.
+#.	The :value:`title`, :value:`subtitle`, :value:`ordinal`, and any `related title epub semantics <https://www.w3.org/TR/epub-ssv-11/>`__ are not included in ToC entries. Their usage context is only within actual heading content.
 
 #.	The text of the :html:`<a>` element is decided as follows:
 

--- a/6-standard-ebooks-section-patterns.rst
+++ b/6-standard-ebooks-section-patterns.rst
@@ -149,7 +149,7 @@ The :html:`<nav>` element’s top-level :html:`<ol>` element contains a list of 
 :html:`<a>` descendents
 -----------------------
 
-#.	The :value:`title`, :value:`subtitle`, :value:`ordinal`, and any `related title epub semantics <https://www.w3.org/TR/epub-ssv-11/>`__ are not included in ToC entries. Their usage context is only within actual heading content.
+#.	The :value:`title`, :value:`subtitle`, :value:`ordinal`, and any `related title epub semantics <https://www.w3.org/TR/epub-ssv-11/#sec-titles>`__ are not included in ToC entries. Their usage context is only within actual heading content.
 
 #.	The text of the :html:`<a>` element is decided as follows:
 


### PR DESCRIPTION
The [EPUB 3 Structural Semantics Vocabulary](https://idpf.github.io/epub-vocabs/structure/) gives a "this document is OBSOLETE" warning and refers to a [newer version](https://www.w3.org/TR/epub-ssv-11/). We may have a specific reason for linking to the old version, but if not, this updates to the linked version.