### PR TITLE
Fix links

### DIFF
--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -495,7 +495,7 @@ Epigraphs in section headers
 				</blockquote>
 			</header>
 
-#.	In addition to the `CSS used for all epigraphs </manual/VERSION/7-high-level-structural-patterns#7.3.1>`__, this additional CSS is included for epigraphs in section headers:
+#.	In addition to the `CSS used for all epigraphs </manual/VERSION/7-high-level-structural-patterns#7.4.1>`__, this additional CSS is included for epigraphs in section headers:
 
 	.. code:: css
 
@@ -528,7 +528,7 @@ Full-page epigraphs
 
 #.	Full-page epigraphs that contain multiple quotations are represented by multiple :html:`<blockquote>` elements.
 
-#.	In addition to the `CSS used for all epigraphs </manual/VERSION/7-high-level-structural-patterns#7.3.1>`__, this additional CSS is included for full-page epigraphs:
+#.	In addition to the `CSS used for all epigraphs </manual/VERSION/7-high-level-structural-patterns#7.4.1>`__, this additional CSS is included for full-page epigraphs:
 
 	.. code:: css
 

--- a/8-typography.rst
+++ b/8-typography.rst
@@ -1368,7 +1368,7 @@ Latinisms
 
 #.	:string:`&c.` is not used, and is replaced with :string:`etc.`.
 
-#.	For :string:`Ibid.`, `see Endnotes </manual/VERSION/7-high-level-structural-patterns#7.9>`__.
+#.	For :string:`Ibid.`, `see Endnotes </manual/VERSION/7-high-level-structural-patterns#7.10>`__.
 
 #.	Latinisms that are abbreviations are set in lowercase with periods between words and no spaces between them, except :string:`BC`, :string:`AD`, :string:`BCE`, and :string:`CE`, which are set without periods, in small caps, and wrapped with :html:`<abbr epub:type="se:era">`:
 

--- a/9-metadata.rst
+++ b/9-metadata.rst
@@ -573,7 +573,7 @@ The :html:`<spine>` element is a required part of the EPUB spec that defines the
 Accessibility metadata
 **********************
 
-Accessibility metadata is added to bring the final ebook into conformance with the `EPUB Accessibility spec <http://www.idpf.org/epub/latest/accessibility>`__, with the following considerations.
+Accessibility metadata is added to bring the final ebook into conformance with the `EPUB Accessibility spec <https://www.w3.org/TR/epub-a11y-11>`__, with the following considerations.
 
 #.	Accessibility metadata is arranged in the metadata file in groups by property, with items in each group ordered by their text values. The groups appear in this order:
 


### PR DESCRIPTION
Updated a few links that were pointing to the wrong section. Also changed the idpf.org accessibility link (obsolete) to the W3C EPUB accessibility page.