### PR TITLE
10: Add Staatliche Kunsthalle Karlsruhe as CC0 museum

### DIFF
--- a/10-art-and-images.rst
+++ b/10-art-and-images.rst
@@ -236,6 +236,8 @@ Images that are explicitly marked as CC0 from these museums can be used without 
 
 -	`Grand Rapids Public Museum <https://www.grpmcollections.org/Browse/Collections>`__ (CC0 items have a link to the CC0 license in the “Rights” section.)
 
+-	`Staatliche Kunsthalle Karlsruhe <https://www.kunsthalle-karlsruhe.de/en/collection/>`__ (CC0 items have a CC0 icon below the picture.)
+
 Clearance FAQ
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
[Example of a CC0 painting](https://www.kunsthalle-karlsruhe.de/kunstwerke/Ferdinand-Keller/K%C3%BCstenlandschaft-bei-Rio-de-Janeiro/C066F030484D7D09148891B0E70524B8/#).

[The license info page (translated).](https://www-kunsthalle--karlsruhe-de.translate.goog/cco/?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp)

The "copyrights" section on the [English newsroom page](https://www.kunsthalle-karlsruhe.de/en/newsroom/) also confirms that the photos are released under the CC0 license.