### PR TITLE
Document non-use of U+2010 hyphen

### DIFF
--- a/8-typography.rst
+++ b/8-typography.rst
@@ -693,7 +693,7 @@ There are many kinds of dashes, and the run-of-the-mill hyphen is often not the 
 
 		<p>His number is 555‒1234.</p>
 
-#.	Hyphens (:utf:`-` or U+002D) are used to join words, including double-barrel names, or to separate syllables in a word.
+#.	Hyphens (:utf:`-` or U+002D) are used to join words, including double-barrel names, or to separate syllables in a word. The Unicode hyphen (U+2010) is not used.
 
 	.. code:: html
 


### PR DESCRIPTION
Though the rejection of #106 is understandable, this does go against Unicode’s explicit recommendation, so I think it should be documented.

Perhaps other uses of “hyphen” in the manual should be replaced with “hyphen‐minus,” but the result when I tried it seemed awkward, so I’ve left it out.