### PR TITLE
Fixes

### DIFF
--- a/5-general-xhtml-and-css-patterns.rst
+++ b/5-general-xhtml-and-css-patterns.rst
@@ -107,7 +107,7 @@ This section covers general patterns used when producing XHTML and CSS that are 
 				</section>
 			</section>
 
-#.	For poems  with the :value:`z3998:poem` semantic in which a child has an :html:`id` attribute referring to a specific line number, the :html:`id` attribute’s value is formed by taking the :html:`id` attribute of the closest parent :html:`<section>` or :html:`<article>` that contains the :value:`z3998:poem` semantic, appending :value:`-line`, then :value:`-N`, where :value:`N` is the sequence number of the line starting at :value:`1` in the *flattened document tree order* of the selected sectioning element, *excluding :html:`<header>` elements*.
+#.	For poems with the :value:`z3998:poem` semantic in which a child has an :html:`id` attribute referring to a specific line number, the :html:`id` attribute’s value is formed by taking the :html:`id` attribute of the closest parent :html:`<section>` or :html:`<article>` that contains the :value:`z3998:poem` semantic, appending :value:`-line`, then :value:`-N`, where :value:`N` is the sequence number of the line starting at :value:`1` in the *flattened document tree order* of the selected sectioning element, *excluding :html:`<header>` elements*.
 
 	.. class:: corrected
 

--- a/5-general-xhtml-and-css-patterns.rst
+++ b/5-general-xhtml-and-css-patterns.rst
@@ -107,7 +107,7 @@ This section covers general patterns used when producing XHTML and CSS that are 
 				</section>
 			</section>
 
-#.	For poems with the :value:`z3998:poem` semantic in which a child has an :html:`id` attribute referring to a specific line number, the :html:`id` attribute’s value is formed by taking the :html:`id` attribute of the closest parent :html:`<section>` or :html:`<article>` that contains the :value:`z3998:poem` semantic, appending :value:`-line`, then :value:`-N`, where :value:`N` is the sequence number of the line starting at :value:`1` in the *flattened document tree order* of the selected sectioning element, *excluding :html:`<header>` elements*.
+#.	For poems with the :value:`z3998:poem` semantic in which a child has an :html:`id` attribute referring to a specific line number, the :html:`id` attribute’s value is formed by taking the :html:`id` attribute of the closest parent :html:`<section>` or :html:`<article>` that contains the :value:`z3998:poem` semantic, appending :value:`-line`, then :value:`-N`, where :value:`N` is the sequence number of the line starting at :value:`1` in the *flattened document tree order* of the selected sectioning element, *excluding* :html:`<header>` *elements*.
 
 	.. class:: corrected
 

--- a/6-standard-ebooks-section-patterns.rst
+++ b/6-standard-ebooks-section-patterns.rst
@@ -274,7 +274,7 @@ The titlepage
 
 #.	The title page has a :html:`<title>` element with the value :string:`Titlepage`.
 
-#.	The titlepage contains one :html:`<section id="titlepage" epub:type="titlepage">` element which in turn contains one :html:`<h1 epub:type="title">` element,  author information, as well as one :html:`<img src="../images/titlepage.svg">` element.
+#.	The titlepage contains one :html:`<section id="titlepage" epub:type="titlepage">` element which in turn contains one :html:`<h1 epub:type="title">` element, author information, as well as one :html:`<img src="../images/titlepage.svg">` element.
 
 #.	The titlepage does not contain the subtitle, if there is one.
 

--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -1422,7 +1422,7 @@ Examples
 			<link href="../css/local.css" rel="stylesheet" type="text/css"/>
 		</head>
 		<body epub:type="backmatter">
-			<nav id="loi"  epub:type="loi">
+			<nav id="loi" epub:type="loi">
 				<h2 epub:type="title">List of Illustrations</h2>
 				<ol>
 					<li>


### PR DESCRIPTION
Second commit fixes incorrectly rendered text. Since it doesn’t appear possible to nest such markup elements in reST, the simplest solution is to only italicise the text around the `html` markup.