### PR TITLE
Update Content MathML semantics requirements

### DIFF
--- a/8-typography.rst
+++ b/8-typography.rst
@@ -1126,7 +1126,7 @@ Math
 					</m:math>
 				</p>
 
-	#.	When possible, Content MathML is used over Presentational MathML. (This may not always be possible depending on the complexity of the work.)
+	#.	When possible, Content MathML is provided in an additional :html:`<m:annotation-xml>` element. (This may not always be possible depending on the complexity of the work.)
 
 		.. class:: corrected
 
@@ -1134,15 +1134,26 @@ Math
 
 				<p>
 					<m:math alttext="x + 1 = y">
-						<m:apply>
-							<m:eq/>
-							<m:apply>
-								<m:plus/>
-								<m:ci>x</m:ci>
-								<m:cn>1</m:cn>
-							</m:apply>
-							<m:ci>y</m:ci>
-						</m:apply>
+						<m:semantics>
+							<m:mrow>
+								<m:mi>x</m:mi>
+								<m:mo>+</m:mo>
+								<m:mn>1</m:mn>
+								<m:mo>=</m:mo>
+								<m:mi>y</m:mi>
+							</m:mrow>
+							<m:annotation-xml encoding="MathML-Content">
+								<m:apply>
+									<m:eq/>
+									<m:apply>
+										<m:plus/>
+										<m:ci>x</m:ci>
+										<m:cn>1</m:cn>
+									</m:apply>
+									<m:ci>y</m:ci>
+								</m:apply>
+							</m:annotation-xml>
+						</m:semantics>
 					</m:math>
 				</p>
 


### PR DESCRIPTION
The manual [states](https://standardebooks.org/manual/1.7.0/8-typography#8.8.8.2.2): “When possible, Content MathML is used over Presentational MathML.”

[This contradicts the EPUB spec:](https://www.w3.org/publishing/epub3/epub-contentdocs.html#sec-xhtml-mathml)

> The `math` element MUST contain only Presentation MathML, with the exception of the `annotation-xml` element.
>
> Content MathML MAY be included within MathML markup in XHTML Content Documents, and, when present, MUST occur within an `annotation-xml` child element of a `semantics` element.

So I modified the example, basing it on [MDN](https://developer.mozilla.org/en-US/docs/Web/MathML/Element/semantics) and [the MathML spec](https://www.w3.org/TR/MathML/chapter5.html).