### PR TITLE
Fix incorrect Content MathML element

### DIFF
--- a/8-typography.rst
+++ b/8-typography.rst
@@ -1125,7 +1125,7 @@ Math
 				<p>
 					<m:math alttext="x + 1 = y">
 						<m:apply>
-							<m:equals/>
+							<m:eq/>
 							<m:apply>
 								<m:plus/>
 								<m:ci>x</m:ci>


### PR DESCRIPTION
Content MathML’s equality element [is spelled `eq`](https://www.w3.org/TR/MathML2/chapter4.html#contm.eq), not `equals`.