### PR TITLE
Fix incorrect Content MathML elements

### DIFF
--- a/8-typography.rst
+++ b/8-typography.rst
@@ -1116,7 +1116,7 @@ Math
 					</m:math>
 				</p>
 
-	#.	When possible, Content MathML is used over Presentational MathML. (This may not always be possible depending on the complexity of the work.)
+	#.	When possible, Content MathML is used over Presentation MathML. (This may not always be possible depending on the complexity of the work.)
 
 		.. class:: corrected
 
@@ -1178,7 +1178,7 @@ Math
 						</m:math>
 					</p>
 
-	#.	When using Presentational MathML, :html:`<m:mrow>` is used to group subexpressions, but only when necessary. Many elements in MathML, like :html:`<m:math>` and :html:`<m:mtd>`, *imply* :html:`<m:mrow>`, and redundant elements are not desirable. See `this section of the MathML spec <https://www.w3.org/Math/draft-spec/mathml.html#chapter3_presm.reqarg>`__ for more details.
+	#.	When using Presentation MathML, :html:`<m:mrow>` is used to group subexpressions, but only when necessary. Many elements in MathML, like :html:`<m:math>` and :html:`<m:mtd>`, *imply* :html:`<m:mrow>`, and redundant elements are not desirable. See `this section of the MathML spec <https://www.w3.org/Math/draft-spec/mathml.html#chapter3_presm.reqarg>`__ for more details.
 
 		.. class:: wrong
 
@@ -1202,7 +1202,7 @@ Math
 					</m:math>
 				</p>
 
-	#.	If a Presentational MathML expression contains a function, the invisible Unicode function application glyph (U+2061) is used as an operator between the function name and its operand. This element looks exactly like the following, including the comment for readability: :html:`<m:mo>⁡<!--hidden U+2061 function application--></m:mo>`. (Note that the preceding element contains an *invisible* Unicode character! It can be revealed with the :bash:`se unicode-names` tool.)
+	#.	If a Presentation MathML expression contains a function, the invisible Unicode function application glyph (U+2061) is used as an operator between the function name and its operand. This element looks exactly like the following, including the comment for readability: :html:`<m:mo>⁡<!--hidden U+2061 function application--></m:mo>`. (Note that the preceding element contains an *invisible* Unicode character! It can be revealed with the :bash:`se unicode-names` tool.)
 
 		.. class:: wrong
 

--- a/8-typography.rst
+++ b/8-typography.rst
@@ -1149,7 +1149,7 @@ Math
 					<p>
 						<m:math alttext="x+1=y">
 							<m:apply>
-								<m:equals/>
+								<m:eq/>
 								<m:apply>
 									<m:plus/>
 									<m:ci>x</m:ci>
@@ -1167,7 +1167,7 @@ Math
 					<p>
 						<m:math alttext="x + 1 = y">
 							<m:apply>
-								<m:equals/>
+								<m:eq/>
 								<m:apply>
 									<m:plus/>
 									<m:ci>x</m:ci>
@@ -1211,11 +1211,11 @@ Math
 				<p>
 					<m:math alttext="f(x)">
 						<m:mi>f</m:mi>
-						<m:row>
+						<m:mrow>
 							<m:mo fence="true">(</m:mo>
 							<m:mi>x</m:mi>
 							<m:mo fence="true">)</m:mo>
-						</m:row>
+						</m:mrow>
 					</m:math>
 				</p>
 
@@ -1227,15 +1227,15 @@ Math
 					<m:math alttext="f(x)">
 						<m:mi>f</m:mi>
 						<m:mo>⁡:utf:`U+2061`<!--hidden U+2061 function application--></m:mo>
-						<m:row>
+						<m:mrow>
 							<m:mo fence="true">(</m:mo>
 							<m:mi>x</m:mi>
 							<m:mo fence="true">)</m:mo>
-						</m:row>
+						</m:mrow>
 					</m:math>
 				</p>
 
-	#.	Expressions grouped by parenthesis or brackets are wrapped in an :html:`<m:row>` element, and fence characters are set using the :html:`<m:mo fence="true">` element. Separators are set using the :html:`<m:mo separator="true">` element. :html:`<m:mfenced>`, which used to imply both fences and separators, is deprecated in the MathML spec and thus is not used.
+	#.	Expressions grouped by parenthesis or brackets are wrapped in an :html:`<m:mrow>` element, and fence characters are set using the :html:`<m:mo fence="true">` element. Separators are set using the :html:`<m:mo separator="true">` element. :html:`<m:mfenced>`, which used to imply both fences and separators, is deprecated in the MathML spec and thus is not used.
 
 		.. class:: wrong
 
@@ -1245,10 +1245,10 @@ Math
 					<m:math alttext="f(x,y)">
 						<m:mi>f</m:mi>
 						<m:mo>⁡:utf:`U+2061`<!--hidden U+2061 function application--></m:mo>
-						<m:fenced>
+						<m:mfenced>
 							<m:mi>x</m:mi>
 							<m:mi>y</m:mi>
-						</m:fenced>
+						</m:mfenced>
 					</m:math>
 				</p>
 
@@ -1260,13 +1260,13 @@ Math
 					<m:math alttext="f(x,y)">
 						<m:mi>f</m:mi>
 						<m:mo>⁡:utf:`U+2061`<!--hidden U+2061 function application--></m:mo>
-						<m:row>
+						<m:mrow>
 							<m:mo fence="true">(</m:mo>
 							<m:mi>x</m:mi>
 							<m:mo separator="true">,</m:mo>
 							<m:mi>x</m:mi>
 							<m:mo fence="true">)</m:mo>
-						</m:row>
+						</m:mrow>
 					</m:math>
 				</p>
 


### PR DESCRIPTION
- `<m:eq>`, not `<m:equals>`
- `<m:mrow>`, not `<m:row>`
- `<m:mfenced>`, not `<m:fenced>`