### PR TITLE
Remove requirement of epub:type on title

### DIFF
--- a/5-general-xhtml-and-css-patterns.rst
+++ b/5-general-xhtml-and-css-patterns.rst
@@ -311,8 +311,6 @@ The :html:`<title>` element
 
 #.	The value of the title element is determined by the algorithm used to determine the file's ToC entry, except that no XHTML tags are allowed in the :html:`<title>` element.
 
-#.	The :html:`<title>` element has its :html:`epub:type` attribute set to :value:`z3998:roman` if the contents of the :html:`<title>` element is entirely a Roman numeral.
-
 Headers
 *******
 


### PR DESCRIPTION
Based on epubcheck output and changes you've made to the corpus, I believe this is no longer applicable?