### PR TITLE
Simplify table CSS and clarify when to use which CSS for them

### DIFF
--- a/5-general-xhtml-and-css-patterns.rst
+++ b/5-general-xhtml-and-css-patterns.rst
@@ -421,7 +421,7 @@ Tables can often be difficult to represent semantically. For understanding the h
 
 #.	:html:`<table>` elements that display a total or summary row at the bottom have that row contained in a :html:`<tfoot>` element.
 
-#.	:html:`<table>` elements that are not used to format plays/dramas, and that do not otherwise inherit a visible margin (for example, they are not children of :html:`<blockquote>`), have :css:`margin: 1em;` or :css:`margin: 1em auto 1em auto;`.
+#.	:html:`<table>` elements that are not used to format plays/dramas, and that do not otherwise inherit a visible margin (for example, they are not children of :html:`<blockquote>`), have :css:`margin: 1em;` (if the table is wide enough to extend to the full width of the page) or :css:`margin: 1em auto;` (if it is not).
 
 Blockquotes
 ***********


### PR DESCRIPTION
The "1em auto 1em auto" CSS for tables can/should be simplified to just "1em auto". But at the same time, this is also a first attempt at clarifying when to use just "1em" vs "1em auto". (Which, I'm guessing at, hopefully semi-intelligently, since I've never seen you suggest just "1em.")
