### PR TITLE
8: Add "inter alia" as an example of a Latinism

### DIFF
--- a/8-typography.rst
+++ b/8-typography.rst
@@ -253,6 +253,8 @@ Italicizing non-English words and phrases
 
 	- :string:`in vitro`
 
+	- :string:`inter alia`
+
 	- :string:`more suo`
 
 Italicizing or quoting newly-used English words


### PR DESCRIPTION
I noticed this had some inconsistent usage in the corpus where it went both ways, but it should be italicized since "inter" could be confused with the English word.