### PR TITLE
Use figure dashes to obscure single digits

### DIFF
--- a/8-typography.rst
+++ b/8-typography.rst
@@ -787,9 +787,9 @@ A partially-obscured word is a word that the author chooses to not divulge by co
 
 	.. code:: html
 
-		<p>It was the year 192:ws:`wj`‒ in the town of Metropolis.</p>
+		<p>It was the year 192‒ in the town of Metropolis.</p>
 
-		<p>His birthday was August 1:ws:`wj`‒, 1911.</p>
+		<p>His birthday was August 1‒, 1911.</p>
 
 #.	A non-breaking hyphen (:utf:`‑` or U+2011) is used when a single letter is obscured in a word.
 

--- a/8-typography.rst
+++ b/8-typography.rst
@@ -783,13 +783,13 @@ A partially-obscured word is a word that the author chooses to not divulge by co
 
 		<p>She arrived on May —, 1922.</p>
 
-#.	A regular hyphen is used in *partially-obscured* years where only the last number is obscured, and in *partially-obscured* days of the month.
+#.	A figure dash is used in *partially-obscured* years where only the last number is obscured, and in *partially-obscured* days of the month.
 
 	.. code:: html
 
-		<p>It was the year 192-	in the town of Metropolis.</p>
+		<p>It was the year 192:ws:`wj`‒ in the town of Metropolis.</p>
 
-		<p>His birthday was August 1-, 1911.</p>
+		<p>His birthday was August 1:ws:`wj`‒, 1911.</p>
 
 #.	A non-breaking hyphen (:utf:`‑` or U+2011) is used when a single letter is obscured in a word.
 


### PR DESCRIPTION
According to Unicode, figure dash is semantically identical to hyphen‐minus. Having a digit’s width seems desirable in this case.

|Before|After|
|-|-|
|![Before](https://github.com/standardebooks/manual/assets/126009/9a07152f-9777-45c9-a598-c09d51fdf69a)|![After](https://github.com/standardebooks/manual/assets/126009/53fcfa50-a36b-40e5-907e-e43e7bdd5527)|

`[^0-9a-zA-Z][0-9][0-9][0-9]-[^0-9a-zA-Z]` should pick up all existing cases in the corpus. To make sure, I also tried the broader `[0-9][0-9]*-[^a-zA-Z]`, but it didn’t catch anything new except false positives.