### PR TITLE
Fix reference to “page scans”

### DIFF
--- a/6-standard-ebooks-section-patterns.rst
+++ b/6-standard-ebooks-section-patterns.rst
@@ -566,7 +566,7 @@ Subsections
 					<a href="https://www.robinwhittleton.com/">Robin Whittleton</a>,<br/>
 					and is based on transcriptions from<br/>
 					<a href="EBOOK_URL#transcriptions">Project Gutenberg</a><br/>
-					and on page scans from the<br/>
+					and on digital scans from the<br/>
 					<a href="EBOOK_URL#page-scans">Internet Archive</a>.</p>
 
 			#.	If the transcriptions or page scans came from different sources:


### PR DESCRIPTION
All the other code snippets reference “digital scans”. This seems to have made it into [Algis Budrys](https://github.com/standardebooks/algis-budrys_short-fiction/blob/8e8b0efd35b3c1f6447153fa9f91c6e073906464/src/epub/text/colophon.xhtml#L25), will fix it there now.