### PR TITLE
Switch signatures to use breaks before them

### DIFF
--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -1183,8 +1183,8 @@ Examples
 		<p epub:type="z3998:salutation">Dearest Auntie,</p>
 		<p>Please may we have some things for a picnic? Gerald will bring them. I would come myself, but I am a little tired. I think I have been growing rather fast.</p>
 		<footer>
-			<p epub:type="z3998:valediction">Your loving niece,</p>
-			<p epub:type="z3998:sender z3998:signature">Mabel</p>
+			<p epub:type="z3998:valediction">Your loving niece,<br/>
+			<b epub:type="z3998:sender z3998:signature">Mabel</b></p>
 			<p epub:type="z3998:postscript"><abbr epub:type="z3998:initialism">P.S.</abbr>:ws:`wj`—Lots, please, because some of us are very hungry.</p>
 		</footer>
 	</blockquote>
@@ -1198,8 +1198,8 @@ Examples
 		<p><span epub:type="z3998:salutation">My dear Brother</span>, At last I am able to send you some tidings of my niece, and such as, upon the whole, I hope will give you satisfaction. Soon after you left me on Saturday, I was fortunate enough to find out in what part of London they were. The particulars, I reserve till we meet. It is enough to know they are discovered, I have seen them both⁠:ws:`wj`—</p>
 		<p>I shall write again as soon as anything more is determined on.</p>
 		<footer>
-			<p epub:type="z3998:valediction">Yours, <abbr class="eoc">etc.</abbr></p>
-			<p epub:type="z3998:sender z3998:signature">Edward Gardner</p>
+			<p epub:type="z3998:valediction">Yours, <abbr>etc.</abbr><br/>
+			<b epub:type="z3998:sender z3998:signature">Edward Gardner</b></p>
 		</footer>
 	</blockquote>
 


### PR DESCRIPTION
Change our examples to reflect that signatures should be preceded by `<br/>`, not their own `<p>`.
I went back and forth on whether the "eoc" was still correct on the "Yours, etc." before the Gardner signature. I left it, but maybe it should go?