### PR TITLE
surround -> surrounded; add inline code markup to CSS value

### DIFF
--- a/8-typography.rst
+++ b/8-typography.rst
@@ -455,7 +455,7 @@ Capitalization
 Indentation
 ***********
 
-#.	Paragraphs that directly follow another paragraph are indented by 1em.
+#.	Paragraphs that directly follow another paragraph are indented by `1em`.
 
 #.	The first line of body text in a section, or any text following a visible break in text flow (like a header, a scene break, a figure etc.), is not indented, with the exception of block quotations.
 

--- a/8-typography.rst
+++ b/8-typography.rst
@@ -414,7 +414,7 @@ Capitalization
 
 #.	Titlecasing, or the capitalization of titles, follows the formula used in the :bash:`se titlecase` tool.
 
-#.	Text in all caps is almost never correct typography. Instead, such text is changed to the correct case and surround with a semantically-meaningful element like :html:`<em>` (for emphasis), :html:`<strong>` (for strong emphasis, like shouting) or :html:`<b>` (for unsemantic formatting required by the text). :html:`<strong>` and :html:`<b>` are styled in small-caps by default in Standard Ebooks.
+#.	Text in all caps is almost never correct typography. Instead, such text is changed to the correct case and surrounded with a semantically-meaningful element like :html:`<em>` (for emphasis), :html:`<strong>` (for strong emphasis, like shouting) or :html:`<b>` (for unsemantic formatting required by the text). :html:`<strong>` and :html:`<b>` are styled in small-caps by default in Standard Ebooks.
 
 	.. class:: wrong
 


### PR DESCRIPTION
Two small fixes in [Section 8.4.1](https://standardebooks.org/manual/1.8.0/8-typography#8.4.1)
- Corrected subject-verb disagreement
- `1em` was not marked up as inline code, which appears to be at odds with how similar values are marked up in other sections