### PR TITLE
Normalise US -> U.S.

### DIFF
--- a/3-the-structure-of-an-ebook.rst
+++ b/3-the-structure-of-an-ebook.rst
@@ -121,6 +121,6 @@ The colophon contains information about the publisher of the book, the author, t
 Copyright Page
 ==============
 
-The copyright page includes information about the copyright status of the work. All Standard Ebooks are in the US Public domain, and use a standardized “copyright” page to explain this.
+The copyright page includes information about the copyright status of the work. All Standard Ebooks are in the U.S. Public domain, and use a standardized “copyright” page to explain this.
 
 Copyright pages are usually part of the front matter of a book, but in the case of Standard Ebooks productions they are back matter, and the last item in the book.

--- a/6-standard-ebooks-section-patterns.rst
+++ b/6-standard-ebooks-section-patterns.rst
@@ -368,17 +368,17 @@ The imprint
 			<head>
 				<title>Imprint</title>
 				<link href="../css/core.css" rel="stylesheet" type="text/css"/>
-				<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+				<link href="../css/se.css" rel="stylesheet" type="text/css"/>
 			</head>
 			<body epub:type="frontmatter">
 				<section id="imprint" epub:type="imprint">
 					<header>
 						<h2 epub:type="title">Imprint</h2>
-						<img alt="The Standard Ebooks logo" src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+						<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
 					</header>
 					<p>This ebook is the product of many hours of hard work by volunteers for <a href="https://standardebooks.org">Standard Ebooks</a>, and builds on the hard work of other literature lovers made possible by the public domain.</p>
 					<p>This particular ebook is based on a transcription from <a href="PG_URL">Project Gutenberg</a> and on digital scans from the <a href="IA_URL">Internet Archive</a>.</p>
-					<p>The writing and artwork within are believed to be in the <abbr>U.S.</abbr> public domain, and Standard Ebooks releases this ebook edition under the terms in the <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0 Universal Public Domain Dedication</a>. For full license information, see the <a href="uncopyright.xhtml">Uncopyright</a> at the end of this ebook.</p>
+					<p>The source text and artwork in this ebook are believed to be in the United States public domain; that is, they are believed to be free of copyright restrictions in the United States. They may still be copyrighted in other countries, so users located outside of the United States must check their local laws before using this ebook. The creators of, and contributors to, this ebook dedicate their contributions to the worldwide public domain via the terms in the <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0 Universal Public Domain Dedication</a>. For full license information, see the <a href="uncopyright.xhtml">Uncopyright</a> at the end of this ebook.</p>
 					<p>Standard Ebooks is a volunteer-driven project that produces ebook editions of public domain literature using modern typography, technology, and editorial standards, and distributes them free of cost. You can download this and other ebooks carefully produced for true book lovers at <a href="https://standardebooks.org">standardebooks.org</a>.</p>
 				</section>
 			</body>

--- a/8-typography.rst
+++ b/8-typography.rst
@@ -1035,7 +1035,7 @@ Punctuation in abbreviated measurements
 
 		<p>A 12:ws:`nbsp`<abbr>mm</abbr> pistol.</p>
 
-#.	Abbreviated `English <https://en.wikipedia.org/wiki/English_units>`__, `Imperial <https://en.wikipedia.org/wiki/Imperial_units>`__, or `US customary <https://en.wikipedia.org/wiki/United_States_customary_units>`__ units that are one word are set in lowercase with a trailing period. They are not initialisms.
+#.	Abbreviated `English <https://en.wikipedia.org/wiki/English_units>`__, `Imperial <https://en.wikipedia.org/wiki/Imperial_units>`__, or `U.S. customary <https://en.wikipedia.org/wiki/United_States_customary_units>`__ units that are one word are set in lowercase with a trailing period. They are not initialisms.
 
 	.. code:: html
 
@@ -1047,7 +1047,7 @@ Punctuation in abbreviated measurements
 
 		<p>There’s a force of over a hundred thousand <abbr epub:type="z3998:initialism">G</abbr>’s.</p>
 
-#.	Abbreviated English, Imperial, or US customary units that are more than one word (like :string:`hp` for :string:`horse power` or :string:`mph` for :string:`miles per hour`) are set in lowercase without periods. They are not initialisms.
+#.	Abbreviated English, Imperial, or U.S. customary units that are more than one word (like :string:`hp` for :string:`horse power` or :string:`mph` for :string:`miles per hour`) are set in lowercase without periods. They are not initialisms.
 
 	.. code:: html
 
@@ -1502,7 +1502,7 @@ Initials and abbreviations
 
 		- :string:`LL.D.` does not have a period in :string:`LL`, because it indicates the plural :string:`Legum`.
 
-#.	Postal codes and abbreviated US states are set in all caps, without periods or spaces, and are wrapped in an :html:`<abbr epub:type="z3998:place">` element.
+#.	Postal codes and abbreviated U.S. states are set in all caps, without periods or spaces, and are wrapped in an :html:`<abbr epub:type="z3998:place">` element.
 
 	.. code:: html
 


### PR DESCRIPTION
I noticed that we’re not consistent, so let’s go for U.S. The example imprint is also out of date, so I’ve copied in the latest template.