### PR TITLE
7: Fix single clause valediction/signature examples

### DIFF
--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -1202,7 +1202,7 @@ Examples
 		<p epub:type="z3998:salutation">Dearest Auntie,</p>
 		<p>Please may we have some things for a picnic? Gerald will bring them. I would come myself, but I am a little tired. I think I have been growing rather fast.</p>
 		<footer>
-			<p epub:type="z3998:valediction">Your loving niece,<br/>
+			<p><span> epub:type="z3998:valediction">Your loving niece,</span><br/>
 			<b epub:type="z3998:sender z3998:signature">Mabel</b></p>
 			<p epub:type="z3998:postscript"><abbr epub:type="z3998:initialism">P.S.</abbr>:ws:`wj`—Lots, please, because some of us are very hungry.</p>
 		</footer>
@@ -1217,7 +1217,7 @@ Examples
 		<p><span epub:type="z3998:salutation">My dear Brother</span>, At last I am able to send you some tidings of my niece, and such as, upon the whole, I hope will give you satisfaction. Soon after you left me on Saturday, I was fortunate enough to find out in what part of London they were. The particulars, I reserve till we meet. It is enough to know they are discovered, I have seen them both⁠:ws:`wj`—</p>
 		<p>I shall write again as soon as anything more is determined on.</p>
 		<footer>
-			<p epub:type="z3998:valediction">Yours, <abbr>etc.</abbr><br/>
+			<p><span epub:type="z3998:valediction">Yours, <abbr>etc.</abbr></span><br/>
 			<b epub:type="z3998:sender z3998:signature">Edward Gardner</b></p>
 		</footer>
 	</blockquote>


### PR DESCRIPTION
I excluded the comma from the valediction as most of the examples I saw also excluded the period from signature when it was present.

The next/master confused me for a minute here. There is already a change to 7 in next, so I pulled next to get it current, then made the change with that (next) as its base, then pushed my branch. The initial diff that GitHub shows is for master, which of course showed your change as well, so I switched it manually to next and the diff now shows only my changes. I hope everything is correct.