### PR TITLE
Clarify place name formatting

### DIFF
--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -1351,7 +1351,6 @@ Examples
 	figure.full-page{
 		break-after: page;
 		break-before: page;
-		break-inside: avoid;
 		margin: 0;
 		max-height: 100vh;
 		text-align: center;
@@ -1379,7 +1378,6 @@ Examples
 
 	/* If the image is meant to be aligned block-level with the text, use this selector... */
 	figure{
-		break-inside: avoid;
 		margin: 1em 40px;
 		text-align: center;
 	}

--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -1202,7 +1202,7 @@ Examples
 		<p epub:type="z3998:salutation">Dearest Auntie,</p>
 		<p>Please may we have some things for a picnic? Gerald will bring them. I would come myself, but I am a little tired. I think I have been growing rather fast.</p>
 		<footer>
-			<p epub:type="z3998:valediction">Your loving niece,<br/>
+			<p><span> epub:type="z3998:valediction">Your loving niece,</span><br/>
 			<b epub:type="z3998:sender z3998:signature">Mabel</b></p>
 			<p epub:type="z3998:postscript"><abbr epub:type="z3998:initialism">P.S.</abbr>:ws:`wj`—Lots, please, because some of us are very hungry.</p>
 		</footer>
@@ -1217,7 +1217,7 @@ Examples
 		<p><span epub:type="z3998:salutation">My dear Brother</span>, At last I am able to send you some tidings of my niece, and such as, upon the whole, I hope will give you satisfaction. Soon after you left me on Saturday, I was fortunate enough to find out in what part of London they were. The particulars, I reserve till we meet. It is enough to know they are discovered, I have seen them both⁠:ws:`wj`—</p>
 		<p>I shall write again as soon as anything more is determined on.</p>
 		<footer>
-			<p epub:type="z3998:valediction">Yours, <abbr>etc.</abbr><br/>
+			<p><span epub:type="z3998:valediction">Yours, <abbr>etc.</abbr></span><br/>
 			<b epub:type="z3998:sender z3998:signature">Edward Gardner</b></p>
 		</footer>
 	</blockquote>

--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -1225,6 +1225,13 @@ Examples
 Images
 ******
 
+..
+	`<figure>` test cases:
+
+	https://standardebooks.org/ebooks/george-grey/polynesian-mythology
+	https://standardebooks.org/ebooks/lewis-carroll/a-tangled-tale
+	https://standardebooks.org/ebooks/geronimo/geronimos-story-of-his-life
+
 #.	Each :html:`<figure>` element has a unique :html:`id` attribute.
 
 	#.	That attribute's name is :value:`illustration-` followed by :value:`-N`, where :value:`N` is the sequence number of the element starting at :value:`1`.
@@ -1275,17 +1282,19 @@ Images
 
 	#.	An optional :html:`<figcaption>` element containing a concise context-dependent caption may follow the :html:`<img>` element within a :html:`<figure>` element. This caption depends on the surrounding context, and is not necessarily (or even ideally) identical to the :html:`<img>` element’s :html:`alt` attribute.
 
-	#.	All figure elements, regardless of positioning, have this CSS:
+	#.	All figure elements have this CSS:
 
 		.. code:: css
 
 			figure{
 				break-inside: avoid;
+				margin: 1em 2.5em;
 			}
 
 			figure img{
 				display: block;
 				margin: auto;
+				max-height: 100vh;
 				max-width: 100%;
 			}
 
@@ -1293,6 +1302,7 @@ Images
 				font-size: smaller;
 				font-style: italic;
 				margin: 1em;
+				text-align: center;
 			}
 
 			figcaption p + p{
@@ -1306,38 +1316,6 @@ Images
 			figure.full-page{
 				break-after: page;
 				break-before: page;
-				margin: 0;
-				max-height: 100vh;
-				text-align: center;
-			}
-
-			@supports(display: flex){
-				figure.full-page{
-					display: flex;
-					flex-direction: column;
-				}
-
-				figure.full-page img{
-					height: 100vh;
-					object-fit: contain;
-				}
-			}
-
-			@supports(display: grid){
-				figure.full-page{
-					display: grid;
-					grid-template-rows: 1fr auto;
-					max-height: 100%;
-				}
-			}
-
-	#.	:html:`<figure>` elements that are meant to be aligned block-level with the text have this additional CSS:
-
-		.. code:: css
-
-			figure{
-				margin: 1em 40px;
-				text-align: center;
 			}
 
 .. class:: no-numbering
@@ -1347,49 +1325,15 @@ Examples
 
 .. code:: css
 
-	/* If the image is meant to be on its own page, use this selector... */
-	figure.full-page{
-		break-after: page;
-		break-before: page;
-		margin: 0;
-		max-height: 100vh;
-		text-align: center;
-	}
-
-	@supports(display: flex){
-		figure.full-page{
-			display: flex;
-			flex-direction: column;
-		}
-
-		figure.full-page img{
-			height: 100vh;
-			object-fit: contain;
-		}
-	}
-
-	@supports(display: grid){
-		figure.full-page{
-			display: grid;
-			grid-template-rows: 1fr auto;
-			max-height: 100%;
-		}
-	}
-
-	/* If the image is meant to be aligned block-level with the text, use this selector... */
-	figure{
-		margin: 1em 40px;
-		text-align: center;
-	}
-
-	/* In all cases, also include the below styles */
 	figure{
 		break-inside: avoid;
+		margin: 1em 2.5em;
 	}
 
 	figure img{
 		display: block;
 		margin: auto;
+		max-height: 100vh;
 		max-width: 100%;
 	}
 
@@ -1397,10 +1341,17 @@ Examples
 		font-size: smaller;
 		font-style: italic;
 		margin: 1em;
+		text-align: center;
 	}
 
 	figcaption p + p{
 		text-indent: 0;
+	}
+
+	/* If the image is meant to be on its own page, also include this selector... */
+	figure.full-page{
+		break-after: page;
+		break-before: page;
 	}
 
 .. code:: html

--- a/8-typography.rst
+++ b/8-typography.rst
@@ -276,7 +276,7 @@ Italicizing or quoting newly-used English words
 Italics in names and titles
 ===========================
 
-#.	Place names, like pubs, bars, or buildings, are not quoted.
+#.	Place names, like pubs, bars, or buildings, are not italicized or quoted.
 
 #.	The names of publications, music, and art that can stand alone are italicized; additionally, the names of transport vessels are italicized. These include, but are not limited to:
 


### PR DESCRIPTION
The place names item says they shouldn't be quoted, but since it's in the section on italics, say they shouldn't be italicized, either.