### PR TITLE
8: Delete repeated word

### DIFF
--- a/8-typography.rst
+++ b/8-typography.rst
@@ -223,7 +223,7 @@ Italicizing non-English words and phrases
 #.	Words that are in an unknown language have their :html:`xml:lang` attribute set to :value:`und`.
 
 
-#.	Some phrases that are not English in origin but that that are common in English prose, and which begin in a word that could be confused with an English word, are always italicized to prevent confusion. An incomplete list follows:
+#.	Some phrases that are not English in origin but that are common in English prose, and which begin in a word that could be confused with an English word, are always italicized to prevent confusion. An incomplete list follows:
 
 	- :string:`sic`
 


### PR DESCRIPTION
The word `that` here was unnecessarily repeated. I noticed this when reviewing the change that was just made to the `next` branch (for the same line).