### PR TITLE
3: Don't capitalize the 'p' in 'public domain'

### DIFF
--- a/3-the-structure-of-an-ebook.rst
+++ b/3-the-structure-of-an-ebook.rst
@@ -121,6 +121,6 @@ The colophon contains information about the publisher of the book, the author, t
 Copyright Page
 ==============
 
-The copyright page includes information about the copyright status of the work. All Standard Ebooks are in the U.S. Public domain, and use a standardized “copyright” page to explain this.
+The copyright page includes information about the copyright status of the work. All Standard Ebooks are in the U.S. public domain, and use a standardized “copyright” page to explain this.
 
 Copyright pages are usually part of the front matter of a book, but in the case of Standard Ebooks productions they are back matter, and the last item in the book.


### PR DESCRIPTION
I think that the `P` in `U.S. Public domain` was capitalized by accident here, as if it were starting a new sentence. Throughout the rest of the manual, `public domain` is not capitalized except in rare cases, like if part of a license's name.