### PR TITLE
7: Various fixes

### DIFF
--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -11,7 +11,7 @@ Sectioning
 
 #.	Major structural divisions of a larger work, like parts, volumes, books, chapters, or subchapters, are contained in a :html:`<section>` element.
 
-#.	Individual items in a larger collection (like a poem in a poetry collection) are contained in a :html:`<article>` element.
+#.	Individual items in a larger collection (like a poem in a poetry collection) are contained in an :html:`<article>` element.
 
 	#.	Collections of very short work, like collections of poems, have all of their content in a single file, and :css:`break-*` CSS is added to generate page breaks between items:
 

--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -1065,7 +1065,7 @@ Letters require particular attention to styling and semantic inflection. Letters
 
 #.	Letters are wrapped in a :html:`<blockquote>` element with the appropriate semantic inflection, usually :value:`z3998:letter`.
 
-#.	Letters that are telegrams have :html:`class="telegram"` are set with :css:`.telegram{ font-variant: all-small-caps; }`.
+#.	Letters that are telegrams have :html:`class="telegram"` and are set with :css:`.telegram{ font-variant: all-small-caps; }`.
 
 Letter headers
 ==============

--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -215,7 +215,7 @@ Header patterns
 			<p epub:type="title">Who Stole the Tarts?</p>
 		</hgroup>
 
-#.	Sections titles and subtitles but no ordinals:
+#.	Sections with titles and subtitles but no ordinals:
 
 	.. code:: html
 

--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -1468,7 +1468,7 @@ Individual endnotes
 
 #.	An endnote is an :html:`<li id="note-n" epub:type="endnote">` element containing one or more block-level text elements and one backlink element.
 
-#.	Each endnote’s contains a backlink, which has the semantic inflection :value:`backlink`, contains the text :string:`↩`, and has the :html:`href` attribute pointing to the corresponding noteref hash.
+#.	Each endnote contains a backlink, which has the semantic inflection :value:`backlink`, contains the text :string:`↩`, and has the :html:`href` attribute pointing to the corresponding noteref hash.
 
 	#.	In endnotes where the last block-level element is a :html:`<p>` element, the backlink goes at the end of the :html:`<p>` element, preceded by exactly one space.
 

--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -1374,7 +1374,7 @@ Examples
 
 .. code:: html
 
-	<p>He saw strange alien text that looked like this: <img alt="A line of alien heiroglyphs." src="../images/illustration-1.svg" epub:type="z3998:illustration se:image.color-depth.black-on-transparent" />. There was nothing else amongst the ruins.</p>
+	<p>He saw strange alien text that looked like this: <img alt="A line of alien hieroglyphs." src="../images/illustration-1.svg" epub:type="z3998:illustration se:image.color-depth.black-on-transparent" />. There was nothing else amongst the ruins.</p>
 
 List of Illustrations (the LoI)
 *******************************

--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -1389,7 +1389,7 @@ If an ebook has any illustrations that a reader may wish to return to while read
 
 	Examples of illustrations that a reader may wish to return to: illustrations of events in the book, like full-page drawings; illustrations essential to the plot, like diagrams of a murder scene; maps; components of the text, like photographs in a documentary narrative.
 
-	Examples of illustration that might *not* belong in an LoI: drawings used to represent a person’s signature, like an X mark; inline drawings representing text in made-up languages; drawings used as layout elements to illustrate forms, tables, or diagrams; illustrative musical scores; decorative end-of-chapter flourishes.
+	Examples of illustrations that might *not* belong in an LoI: drawings used to represent a person’s signature, like an X mark; inline drawings representing text in made-up languages; drawings used as layout elements to illustrate forms, tables, or diagrams; illustrative musical scores; decorative end-of-chapter flourishes.
 
 #.	The LoI file contains a single :html:`<nav id="loi" epub:type="loi">` element, which in turn contains an :html:`<h2 epub:type="title">List of Illustrations</h2>` element, followed by an :html:`<ol>` element, which in turn contains list items representing the images.
 

--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -628,7 +628,7 @@ Unfortunately there’s no great way to semantically format poetry in HTML. As s
 			text-indent: -1em;
 		}
 
-#.	Poems, songs, and verse that are shorter part of a longer work, like a novel, are wrapped in a :html:`<blockquote>` element.
+#.	Poems, songs, and verse that are a shorter part of a longer work, like a novel, are wrapped in a :html:`<blockquote>` element.
 
 	.. code:: html
 

--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -1284,7 +1284,7 @@ Images
 
 	#.	An optional :html:`<figcaption>` element containing a concise context-dependent caption may follow the :html:`<img>` element within a :html:`<figure>` element. This caption depends on the surrounding context, and is not necessarily (or even ideally) identical to the :html:`<img>` element’s :html:`alt` attribute.
 
-	#.	All figure elements have this CSS:
+	#.	All :html:`<figure>` elements have this CSS:
 
 		.. code:: css
 


### PR DESCRIPTION
A short summary of the proposals suggested here:
1. The first commit (`b03c19b`) fixes a minor grammatical error.
2. The next two commits each add in a missing word.
3. The fourth commit adds in a missing article.
4. The fifth commit just adds markup to show that `<figure>` is an HTML element.
5. The sixth commit corrects a spelling mistake.
6. The seventh commit is a minor grammatical/phrasing correction.
7. The eighth commit removes a possessive marker from the word `endnote`, which did not make sense with how the sentence was phrased. I'm not sure if there was a word missing there.