### PR TITLE
8: Add 'pace' to list of Latin-language expressions that should be italicized

### DIFF
--- a/8-typography.rst
+++ b/8-typography.rst
@@ -261,6 +261,8 @@ Italicizing non-English words and phrases
 
 	- :string:`more suo`
 
+	- :string:`pace`
+
 Italicizing or quoting newly-used English words
 ===============================================
 


### PR DESCRIPTION
According to Merriam-Webster ([see pace, definition 3](https://www.merriam-webster.com/dictionary/pace)), `pace` is usually italicized. More importantly, it should be italicized according to [SEMoS §8.2.9.9](https://standardebooks.org/manual/1.8.2/8-typography#8.2.9.9).