### PR TITLE
Update ligatures

### DIFF
--- a/8-typography.rst
+++ b/8-typography.rst
@@ -546,7 +546,7 @@ Chapter headers
 Ligatures
 *********
 
-Ligatures are two or more letters that are combined into a single letter, usually for stylistic purposes. In general they are not used in modern English spelling, and are replaced with their expanded characters.
+Ligatures are two or more letters that are combined into a single letter, usually for stylistic purposes. In general they are not used in modern English spelling, and are replaced with their expanded characters. Latin ligatures are for presentation only, so they are replaced as well, including in Latin publication names.
 
 Words in non-English languages like French may use ligatures to differentiate words or pronunciations. In these cases, ligatures are retained.
 


### PR DESCRIPTION
We have 60+ works in the corpus that have Latin ligatures (it's on my list of things to fix). You have said multiple times on the list that we replace those, so I thought we should say that explicitly in the manual. I suspect producers are considering Latin as part of the "non-English" section, even though Latin ligatures aren't orthographic.
I wasn't sure about the publications, but we've changed dashed words in publication names to single in the past, so I went with those would be updated as well. If you don't want to do that, let me know and I'll remove that part.

---

I was going to open an issue to ask this question, but since I have you here…
Section 7.7.3.6 says that salutations are wrapped in a `span`, or a `b` if small caps are desired. But our standard letter CSS in 7.7.4.6.1 includes salutation in the list of tags that are small-capped. This causes confusion for both producers and editors, and has lead (at least in my case, but I've seen it discussed on-list as well) to some back and forth on which should be used on salutations. The other items in the list don't have that; for example, signature is discussed in 7.7.4.4, but just says add the tag and "appropriate CSS".

If you want 7.7.3.6 to be the rule for salutations, then I think we should remove salutation from the list of small-capped tags in 7.7.4.6.1. If you want the CSS to be the driving factor, then we should remove the reference to the `b` in 7.7.3.6.