### PR TITLE
7: Remove unneeded epigraph CSS

### DIFF
--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -474,12 +474,6 @@ Epigraphs in section headers
 
 	.. class:: corrected
 
-		.. code:: css
-
-			header [epub|type~="epigraph"] cite{
-				font-variant: small-caps;
-			}
-
 		.. code:: html
 
 			<header>


### PR DESCRIPTION
I'm not sure why this CSS is here. The standard "all epigraphs" CSS immediately above already includes css for `[epub|type~="epigraph"] cite`, so this case is already covered. And the example is about not including the em-dash in the cite, not the formatting.