### PR TITLE
6: Fix reference to wrong CSS file in titlepage template

### DIFF
--- a/6-standard-ebooks-section-patterns.rst
+++ b/6-standard-ebooks-section-patterns.rst
@@ -289,7 +289,7 @@ The titlepage
 			<head>
 				<title>Titlepage</title>
 				<link href="../css/core.css" rel="stylesheet" type="text/css"/>
-				<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+				<link href="../css/se.css" rel="stylesheet" type="text/css"/>
 			</head>
 			<body epub:type="frontmatter">
 				<section id="titlepage" epub:type="titlepage">


### PR DESCRIPTION
The manual is inconsistent with the boilerplate that we generate and actually use in production.