### PR TITLE
7: Adjust signature CSS example

### DIFF
--- a/7-high-level-structural-patterns.rst
+++ b/7-high-level-structural-patterns.rst
@@ -1147,11 +1147,11 @@ Letter footers
 
 #.	The valediction (for example, “Yours Truly” or “With best regards”) has the semantic inflection of :value:`z3998:valediction`.
 
-#.	The sender’s name has semantic inflection of :value:`z3998:sender`. If the name appears to be a signature to the letter, it has the :value:`z3998:signature` semantic inflection and corresponding CSS.
+#.	The sender’s name has semantic inflection of :value:`z3998:sender`. If the name appears to be a signature to the letter, it has the :value:`z3998:signature` semantic inflection. If it is the only element in a paragraph, it also has corresponding CSS.
 
 	.. code:: css
 
-		[epub|type~="z3998:signature"]{
+		p[epub|type~="z3998:signature"]{
 			font-variant: small-caps;
 		}
 


### PR DESCRIPTION
Per SEMoS 5.10, a signature only needs CSS if it is the only element in the paragraph; if it's just a part of a clause, then formatting is done with `<b>`. (This is also already discussed in the letter section.) For this reason, the example CSS in 7.7.4.4 should have a `p` in front of it, and the existing text on that example should probably mention when the CSS is needed.

I expect you'll want to change the wording, just let me know what you would like it to be. :)